### PR TITLE
multi shuttle sdk test support

### DIFF
--- a/src/ttcontrol/factory/default.py
+++ b/src/ttcontrol/factory/default.py
@@ -2,18 +2,19 @@ from ttboard.demoboard import DemoBoard
 import ttboard.util.shuttle_tests as st
 
 tt = DemoBoard.get()
-
-err = st.factory_test_bidirs(tt)
+try:
+    err = st.factory_test_clocking_04(tt)
+except AttributeError:
+    err = 'Unsupported Test Method'
+    
 okay = True
 
 if err is not None:
-    print(f"error=factory_test_bidirs, {err}")
-    okay = False
-
-err = st.factory_test_clocking(tt)
-if err is not None:
     print(f"error=factory_test_clocking, {err}")
     okay = False
+    
+    
+# TODO: bidir test through factory test project
 
 if okay:
     print("factory_test=OK")

--- a/src/ttcontrol/factory/tt03p5.py
+++ b/src/ttcontrol/factory/tt03p5.py
@@ -3,14 +3,29 @@ import ttboard.util.shuttle_tests as st
 
 tt = DemoBoard.get()
 
-err = st.factory_test_bidirs(tt)
+
+# we have many SDK versions floating around
+# for tt03p5, some sad try blocks here to
+# account for changes
+try:
+    # testchip specific naming in latest sdk
+    err = st.factory_test_bidirs_03p5(tt)
+except AttributeError:
+    err = st.factory_test_bidirs(tt)
+
 okay = True
 
 if err is not None:
     print(f"error=factory_test_bidirs, {err}")
     okay = False
 
-err = st.factory_test_clocking(tt)
+
+try:
+    # testchip specific naming in latest sdk
+    err = st.factory_test_clocking_03p5(tt)
+except AttributeError:
+    err = st.factory_test_clocking(tt)
+
 if err is not None:
     print(f"error=factory_test_clocking, {err}")
     okay = False


### PR DESCRIPTION
We have multiple SDK versions supporting multiple shuttles and this has led to some unfortunate exceptions/changes in naming.

This should fix commander factory test in a way that support tt03p5 demoboards with either the old (Sam) version of the SDK or anything more recent, as well as tt04 boards.  That system needs a refactor, but for now we just need to get passed the QC stage during PCBA and this will hopefully handle all the cases.