### PR TITLE
feat(ttcontrol): Control clock while resetting project

### DIFF
--- a/src/ttcontrol/ttcontrol.py
+++ b/src/ttcontrol/ttcontrol.py
@@ -92,13 +92,27 @@ def select_design(design, clock_hz=None):
     dump_state()
 
 
-def reset_project():
+def reset_project(reset_clocks=10):
     tt = DemoBoard.get()
+
+    # Record whether project is currently being clocked, stop the clock if so
+    hz = tt.auto_clocking_freq
+    if hz > 0:
+        tt.clock_project_stop()
+
+    # Reset and clock several times while in reset
     tt.reset_project(True)
+    manual_clock(reset_clocks)
+
+    # Do not have the clock running when bringing the project out of reset, 
+    # to avoid synchronization issues.
     tt.reset_project(False)
 
     report("tt.reset_project", 1)
 
+    # Restart the clock if it was previously running
+    if hz > 0:
+        set_clock_hz(hz)
 
 def set_clock_hz(hz):
     tt = DemoBoard.get()


### PR DESCRIPTION
This change ensures that the design is clocked several times while in reset (10 by default), fixing #3.

The clock is held setady when the design is brought out of reset, avoiding possible reset synchronization problems in designs that do not have synchronizers for `rst_n`.  Then the clock is restarted if it was previously running.