### PR TITLE
Adding a UART tab.

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -14,6 +14,7 @@ import { FirmwareUpgradeRequired } from './FirmwareUpgradeRequired';
 import { Footer } from './Footer';
 import { Header } from './Header';
 import { LoadingButton } from './LoadingButton';
+import { UARTPanel } from './UARTPanel';
 
 export function App() {
   const [supported, setSupported] = createSignal(false);

--- a/src/components/BoardCommander.tsx
+++ b/src/components/BoardCommander.tsx
@@ -14,12 +14,13 @@ import { DebugLogs } from './DebugLogs';
 import { InteractPanel } from './InteractPanel';
 import { PinoutPanel } from './PinoutPanel';
 import { ReplPanel } from './ReplPanel';
+import { UARTPanel } from './UARTPanel';
 
 export interface IBreakoutControlProps {
   device: TTBoardDevice;
 }
 
-type ITabName = 'config' | 'interact' | 'pinout' | 'repl';
+type ITabName = 'config' | 'interact' | 'pinout' | 'repl' | 'uart';
 
 export function BoardCommander(props: IBreakoutControlProps) {
   const [activeTab, setActiveTab] = createSignal<ITabName>('config');
@@ -106,6 +107,12 @@ export function BoardCommander(props: IBreakoutControlProps) {
           >
             REPL
           </Button>
+          <Button
+            onClick={() => setActiveTab('uart')}
+            variant={activeTab() === 'uart' ? 'contained' : 'outlined'}
+          >
+            UART
+          </Button>
         </ButtonGroup>
         <Show when={activeTab() === 'config'}>
           <BoardConfigPanel device={props.device} />
@@ -118,6 +125,9 @@ export function BoardCommander(props: IBreakoutControlProps) {
         </Show>
         <Show when={activeTab() === 'repl'}>
           <ReplPanel device={props.device} />
+        </Show>
+        <Show when={activeTab() === 'uart'}>
+          <UARTPanel device={props.device} />
         </Show>
       </Paper>
 

--- a/src/components/UARTPanel.tsx
+++ b/src/components/UARTPanel.tsx
@@ -1,0 +1,60 @@
+import { Stack, Typography } from '@suid/material';
+import { FitAddon } from '@xterm/addon-fit';
+import { onCleanup, onMount } from 'solid-js';
+import { Terminal } from '@xterm/xterm';
+import '@xterm/xterm/css/xterm.css';
+import { TTBoardDevice } from '~/ttcontrol/TTBoardDevice';
+
+import uartScript from '~/ttcontrol/uart.py?raw';
+
+export interface IUARTPanelProps {
+  device: TTBoardDevice;
+}
+
+export function UARTPanel(props: IUARTPanelProps) {
+  let ref: HTMLDivElement;
+  let terminal: Terminal;
+
+  onMount(async () => {
+    terminal = new Terminal({});
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+
+    // eslint-disable-next-line solid/reactivity
+    const { device } = props;
+
+    // Start UART monitoring
+    device.attachTerminal((data) => terminal.write(data));
+
+    terminal.onData((data) => {
+      device.terminalWrite(data);
+    });
+
+    setTimeout(() => {
+      terminal.open(ref);
+
+      // Send Ctrl+E to enter paste mode
+      device.terminalWrite(`\x05`);
+      // Send the UART script
+      device.terminalWrite(uartScript);
+      // Send Ctrl+D to exit paste mode
+      device.terminalWrite(`\x04`);
+
+      fitAddon.fit();
+      terminal.focus();
+    });
+
+    onCleanup(() => {
+      device.detachTerminal();
+    });
+  });
+
+  return (
+    <Stack>
+      <div ref={ref!} />
+      <Typography marginTop={0.5}>
+        UART Monitor: TX on ui_in3, RX on uo_out4 at 115200 baud
+      </Typography>
+    </Stack>
+  );
+}

--- a/src/ttcontrol/uart.py
+++ b/src/ttcontrol/uart.py
@@ -1,0 +1,14 @@
+import uselect
+import sys
+from machine import UART
+
+uart = UART(0, baudrate=115200, tx=tt.pins.ui_in3.raw_pin, rx=tt.pins.uo_out4.raw_pin)
+poll = uselect.poll()
+poll.register(sys.stdin, uselect.POLLIN)
+
+while True:
+    if poll.poll(0):
+        _ = uart.write(sys.stdin.buffer.read(1))
+    uart_data = uart.read()
+    if uart_data:
+        _ = sys.stdout.write(uart_data)


### PR DESCRIPTION
Fixes #33.

Follows the instructions from
[Booting Linux on Tiny Tapeout 6 - KianV RISC-V SOC](https://docs.google.com/document/d/1xsKXSyzRcITReSPcTtEUlEqfY_uygV3ntWclOUEb7FA/edit?tab=t.0)

See screenshot below;
![image](https://github.com/user-attachments/assets/4c05c912-a012-40dd-a106-d5f037e181b4)
